### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Cryptex",
-            dependencies: ["CryptoSwift"], path: ".", exclude: ["Tests"]),
+            dependencies: ["CryptoSwift"], path: ".", exclude: ["Tests", "CryptexTests"]),
         .testTarget(
             name: "CryptexTests",
             dependencies: ["Cryptex"]),


### PR DESCRIPTION
Without this change, SPM fails with:

```bash
rob@MacBook ~/P/s/ddc> swift run
Compile Swift Module 'Cryptex' (24 sources)
/Users/rob/Projects/swift.workspace/ddc/.build/checkouts/Cryptex.git--8883681985385158736/CryptexTests/CryptexTests.swift:10:18: warning: file 'CryptexTests.swift' is part of module 'Cryptex'; ignoring import
@testable import Cryptex
                 ^
Compile Swift Module 'ddc' (1 sources)
Linking ./.build/x86_64-apple-macosx10.10/debug/ddc
dyld: Library not loaded: @rpath/XCTest.framework/Versions/A/XCTest
  Referenced from: /Users/rob/Projects/swift.workspace/ddc/.build/x86_64-apple-macosx10.10/debug/ddc
  Reason: image not found
fish: Job 3, 'swift run' terminated by signal SIGABRT (Abort)
```

I assume because the directory is incorrectly named "CryptexTests" and not "Tests".